### PR TITLE
KAN-17 / 타이틀 폰트 바꾸기

### DIFF
--- a/src/components/basic/Header.vue
+++ b/src/components/basic/Header.vue
@@ -3,12 +3,10 @@ import { routes } from "../../plugins/router.ts";
 </script>
 
 <template>
-  <v-app-bar flat>
-    <v-container class="mx-auto d-flex align-center justify-center">
-      <v-app-bar-title @click="$router.push('/')"
-        >BLOG DU CINEMA
-      </v-app-bar-title>
-      <v-spacer></v-spacer>
+  <v-app-bar >
+    <v-container id="header" class="mx-auto my-auto d-flex align-center justify-center">
+      <v-app-bar-title id="blog-title" @click="$router.push('/')"
+        >LE BLOG DU CINÉMA</v-app-bar-title>
       <v-btn v-for="(menu, i) in routes.slice(1)" :key="i" :to="menu.path">
         {{ menu.name }}
       </v-btn>
@@ -16,4 +14,18 @@ import { routes } from "../../plugins/router.ts";
   </v-app-bar>
 </template>
 
-<style scoped></style>
+<style scoped>
+@import url('https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,600&display=swap');
+
+#blog-title {
+  font-family: 'Bodoni Moda', serif;
+  font-optical-sizing: auto;
+  font-style: normal;
+  font-weight: 600;
+  width: auto;
+}
+
+#header {
+  height: auto;
+}
+</style>


### PR DESCRIPTION
타이틀인 'LE BLOG DU CINÉMA’의 폰트를 바꾼다.

구글 폰트에서 bodoni를 찾아서 cdn 링크를 연결시킨다.

app bar title의 넓이도 auto로 지정해준다.

타이틀을 키우고 싶은데, 이게 타이틀 영역을 넓히는 방법을 모른다.

텍스트만 키우면 짤린다.


